### PR TITLE
Fix exception when hovering at the edge of the globe

### DIFF
--- a/src/globe.js
+++ b/src/globe.js
@@ -380,6 +380,8 @@ export default Kapsule({
         };
 
         const globeObj = getGlobeObj(obj);
+        if (!globeObj) return '';
+
         const objType = globeObj.__globeObjType;
 
         return globeObj && objAccessors.hasOwnProperty(objType) && dataAccessors.hasOwnProperty(objType)


### PR DESCRIPTION
Hi, and thank you for this awesome library!

I ran into the same issue as the guys here: https://github.com/vasturiano/react-globe.gl/issues/46

I found that this is due to a missing null check.

Steps to reproduce the issue (at least on Chrome, Mac):
1. open for instance the basic example https://globe.gl/example/basic/
2. open the JS console to see the error
3. start hovering at the edge of the globe, where the atmosphere and Earth meet
4. you get the error which stops further event processing (the globe "locks up")

This pull request adds the null check.