### PR TITLE
Handle null Propagate Results to Prevent TypeError and Animation Lag

### DIFF
--- a/example/satellites/index.html
+++ b/example/satellites/index.html
@@ -64,11 +64,16 @@
         const gmst = satellite.gstime(time);
         satData.forEach(d => {
           const eci = satellite.propagate(d.satrec, time);
-          if (eci.position) {
+          if (eci?.position) {
             const gdPos = satellite.eciToGeodetic(eci.position, gmst);
             d.lat = satellite.radiansToDegrees(gdPos.latitude);
             d.lng = satellite.radiansToDegrees(gdPos.longitude);
-            d.alt = gdPos.height / EARTH_RADIUS_KM
+            d.alt = gdPos.height / EARTH_RADIUS_KM;
+          } else {
+            // explicitly handle invalid position
+            d.lat = NaN;
+            d.lng = NaN;
+            d.alt = NaN;
           }
         });
 


### PR DESCRIPTION
The previous fix #239 did not consider the case of `null` position returned by satellite.js later on in the code:
```javascript
          const eci = satellite.propagate(d.satrec, time);
          if (eci.position) {
            const gdPos = satellite.eciToGeodetic(eci.position, gmst);
            d.lat = satellite.radiansToDegrees(gdPos.latitude);
            d.lng = satellite.radiansToDegrees(gdPos.longitude);
            d.alt = gdPos.height / EARTH_RADIUS_KM
          }
```
Accessing `eci.position` throws TypeError in those cases and causes the animation to lag. Since downstream code already catches `NaN` in positions, this PR explicitly assigns `NaN` to lat, lng, and alt when propagation fails.

Fix:
```javascript
          const eci = satellite.propagate(d.satrec, time);
          if (eci?.position) {
            const gdPos = satellite.eciToGeodetic(eci.position, gmst);
            d.lat = satellite.radiansToDegrees(gdPos.latitude);
            d.lng = satellite.radiansToDegrees(gdPos.longitude);
            d.alt = gdPos.height / EARTH_RADIUS_KM;
          } else {
            // explicitly handle invalid position
            d.lat = NaN;
            d.lng = NaN;
            d.alt = NaN;
          }
```