### PR TITLE
fix(types): add missing hexPolygonLabel to type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -58,6 +58,8 @@ interface GlobeGenericInstance<ChainableInstance>
   pathLabel(textAccessor: ObjAccessor<Label>): ChainableInstance;
   hexLabel(): Accessor<HexBin, Label>;
   hexLabel(textAccessor: Accessor<HexBin, Label>): ChainableInstance;
+  hexPolygonLabel(): ObjAccessor<Label>;
+  hexPolygonLabel(textAccessor: ObjAccessor<Label>): ChainableInstance;
   tileLabel(): ObjAccessor<Label>;
   tileLabel(textAccessor: ObjAccessor<Label>): ChainableInstance;
   particleLabel(): ObjAccessor<Label>;


### PR DESCRIPTION
`hexPolygonLabel` is a public accessor (`src/globe.js`, documented in the README with default `name`), but it's the only label accessor missing from `index.d.ts` — its siblings (`polygonLabel`, `hexLabel`, `onHexPolygonClick`/`RightClick`/`Hover`, etc.) are all typed. So `globe.hexPolygonLabel(...)` doesn't type-check.

### Before

```ts
declare const g: GlobeInstance;
g.hexPolygonLabel('name');
// error TS2551: Property 'hexPolygonLabel' does not exist on type
// 'GlobeInstance'. Did you mean 'polygonLabel'?
```

### Fix / After

Added the standard getter/setter overload next to the other label accessors, matching `polygonLabel` (hex-polygon objects are plain objects, so `ObjAccessor<Label>`). The same snippet now type-checks cleanly.

*Written with AI assistance; I've reviewed and tested the change and will maintain it.*
